### PR TITLE
fix CustomBuildConfig usage

### DIFF
--- a/LAI_voice_search_openai_whisper_demo/components/web_ui.py
+++ b/LAI_voice_search_openai_whisper_demo/components/web_ui.py
@@ -23,10 +23,10 @@ class LitGradio(ServeGradio):
     # examples = [['Is 42 the answer to everything?']]
 
     def __init__(self):
-        super().__init__(parallel=True)
-
         # Use the custom build config
         self.cloud_build_config = CustomBuildConfig()
+        super().__init__(parallel=True)
+
         # self._cloud_build_config = CustomBuildConfig(requirements=["ffmpeg-python"])
         # super().__init__(parallel=True, host='0.0.0.0', port=8888)
 


### PR DESCRIPTION
The correct way would be to either pass the config in the `super().__init__()` call or `self. cloud_build_config` before calling super initialization