### PR TITLE
Reverting "fix CustomBuildConfig usage"

### DIFF
--- a/LAI_voice_search_openai_whisper_demo/components/web_ui.py
+++ b/LAI_voice_search_openai_whisper_demo/components/web_ui.py
@@ -23,10 +23,10 @@ class LitGradio(ServeGradio):
     # examples = [['Is 42 the answer to everything?']]
 
     def __init__(self):
-        # Use the custom build config
-        self.cloud_build_config = CustomBuildConfig()
         super().__init__(parallel=True)
 
+        # Use the custom build config
+        self.cloud_build_config = CustomBuildConfig()
         # self._cloud_build_config = CustomBuildConfig(requirements=["ffmpeg-python"])
         # super().__init__(parallel=True, host='0.0.0.0', port=8888)
 


### PR DESCRIPTION
Reverts Nachimak28/LAI-voice-search-openai-whisper-demo#1

So Sorry about that, I merged it without thinking, only reverting because this led to a new issue and does not deploy on cloud

```
Traceback (most recent call last):
  File "app.py", line 16, in <module>
    app = L.LightningApp(RootFlow())
  File "app.py", line 8, in __init__
    self.lit_gradio = LitGradio()
  File "c:\users\hp\desktop\oss\lai-voice-search-openai-whisper-demo\LAI_voice_search_openai_whisper_demo\components\web_ui.py", line 27, in __init__
    self.cloud_build_config = CustomBuildConfig()
  File "C:\Users\HP\.conda\envs\lit\lib\site-packages\lightning_app\core\work.py", line 326, in __setattr__
    property_object.fset(self, value)
  File "C:\Users\HP\.conda\envs\lit\lib\site-packages\lightning_app\core\work.py", line 222, in cloud_build_config
    self._cloud_build_config.on_work_init(self, cloud_compute=self._cloud_compute)
  File "C:\Users\HP\.conda\envs\lit\lib\site-packages\lightning_app\core\work.py", line 428, in __getattr__
    return self.__getattribute__(item)
  File "C:\Users\HP\.conda\envs\lit\lib\site-packages\lightning_app\core\work.py", line 411, in __getattribute__
    raise e
  File "C:\Users\HP\.conda\envs\lit\lib\site-packages\lightning_app\core\work.py", line 407, in __getattribute__
    attr = object.__getattribute__(self, name)
AttributeError: 'LitGradio' object has no attribute '_cloud_compute'
```

